### PR TITLE
feat: 업스트림 레포 싱크 액션

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+on:
+  schedule:
+    - cron: '0 0 * * *' # Every day at midnight (UTC)
+  workflow_dispatch: # Manual trigger
+
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: repo-sync
+        uses: repo-sync/github-sync@v2
+        with:
+          source_repo: 'ccbikai/Sink'
+          source_branch: 'master'
+          destination_branch: 'master'
+          sync_tags: 'true'
+          github_token: ${{ secrets.PAT }}


### PR DESCRIPTION
- `master` 브랜치에서 액션을 설정하면 업스트림 내용을 그대로 덮어쓰기 때문에 액션 파일이 사라짐
- 포크한 레포지토리의 기본 브랜치를 `action`으로 설정하면 `action` 브랜치에서 액션 작동可 (깃헙 액션은 기본 브랜치에서만 자동 실행됨)
- 이후 업스트림 레포지토리가 업데이트될 때 `action` 브랜치의 액션을 실행해서 `master` 브랜치 동기화 되도록 설정